### PR TITLE
chore: improve package discoverability and metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 JiayiXie
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # minipet-overlay
 
-AI 编程搭子 — 陪你写代码的亲密伙伴
+[![npm version](https://img.shields.io/npm/v/minipet-overlay.svg)](https://www.npmjs.com/package/minipet-overlay)
+[![npm downloads](https://img.shields.io/npm/dw/minipet-overlay.svg)](https://www.npmjs.com/package/minipet-overlay)
+[![license](https://img.shields.io/npm/l/minipet-overlay.svg)](https://github.com/JiayiXie-jpg/minipet-overlay/blob/main/LICENSE)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D18-brightgreen.svg)](https://nodejs.org/)
+
+**AI 编程搭子 — 陪你写代码的亲密伙伴**
+
+> A desktop AI coding companion with animated avatars and TTS voice — cheers you on while you code with Claude Code.
 
 桌面悬浮窗形式的 AI 编程搭子，用动画和语音为你加油打气。支持自定义形象，默认内置莎莎。
+
+<!-- 📸 欢迎提交截图或 GIF 到此处展示效果！ -->
+<!-- <p align="center"><img src="docs/demo.gif" width="400" /></p> -->
 
 ## 架构
 
@@ -121,3 +131,13 @@ minipet-overlay list                           # 查看可用形象
 - **桌面**: Electron 透明无框悬浮窗
 - **形象生成**: Vision LLM + Seedream + Seedance + SAM3
 - **事件源**: claude-minipet Claude Code hooks
+
+## Contributing
+
+欢迎贡献代码！请提交 Issue 或 Pull Request。
+
+Contributions are welcome! Feel free to open an issue or submit a pull request.
+
+## License
+
+[MIT](LICENSE) &copy; [JiayiXie](https://github.com/JiayiXie-jpg)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minipet-overlay",
   "version": "3.3.4",
-  "description": "AI 编程搭子 — 支持自定义形象的桌面编程搭子",
+  "description": "AI 编程搭子 — 支持自定义形象的桌面编程搭子 | AI coding companion with custom avatars, animations & TTS",
   "main": "dist-electron/main.js",
   "bin": {
     "minipet-overlay": "./dist/cli.js"
@@ -18,6 +18,28 @@
     "build": "tsc && tsc -p tsconfig.electron.json",
     "postinstall": "node dist/setup.js",
     "start": "node dist/cli.js start"
+  },
+  "keywords": [
+    "desktop-pet",
+    "electron",
+    "claude",
+    "claude-code",
+    "ai-companion",
+    "coding-companion",
+    "overlay",
+    "tts",
+    "desktop-overlay",
+    "virtual-pet"
+  ],
+  "author": "JiayiXie <JiayiXie@whu.edu.cn>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JiayiXie-jpg/minipet-overlay.git"
+  },
+  "homepage": "https://github.com/JiayiXie-jpg/minipet-overlay#readme",
+  "bugs": {
+    "url": "https://github.com/JiayiXie-jpg/minipet-overlay/issues"
   },
   "dependencies": {
     "electron": "^33.0.0",


### PR DESCRIPTION
## Summary

- **package.json**: Added `keywords`, `author`, `license`, `repository`, `homepage`, `bugs` fields; enhanced `description` with English tagline
- **LICENSE**: Added MIT license file
- **README.md**: Added npm/license/node badges, English one-liner, GIF placeholder, Contributing section, License footer
- **GitHub topics**: Set 9 topics (desktop-pet, electron, claude-code, ai-companion, virtual-pet, coding-companion, tts, overlay, typescript)

## Why

The package has 2400+ npm downloads in its first week but 0 GitHub stars and low discoverability. These changes improve SEO on both npm and GitHub, make the project look more professional, and lower the barrier for contributors.

## Test plan

- [ ] Verify badges render correctly on GitHub README
- [ ] Verify `npm info minipet-overlay` shows new fields after next publish
- [ ] Confirm topics appear on the GitHub repo page (already applied via API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)